### PR TITLE
Fixed typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A package containing functions to interact with the mangal API and database.
 
 ## Getting Started
 
-Go to this page: `poisotlab.biol.umontreal.ca/auth` to retrieve your acces_token. You will have to create an Orcid account if you don't have one. Once you have registered, you will be directed to a page with your orcid id and a acces_token. Copy your acces_token. Create the ```.httr-oauth``` file in the package directory ```../mangal.package/R``` with ```saveRDS('your acces_token')```.
+Go to this page: `poisotlab.biol.umontreal.ca/auth` to retrieve your acces_token. You will have to create an Orcid account if you don't have one. Once you have registered, you will be directed to a page with your orcid id and an access_token. Copy your access_token. Create the ```.httr-oauth``` file in the package directory ```../mangal.package``` with ```saveRDS('your access_token')```.
 
 ## Authors
 
 * **Steve Vissault** - *Initial work* - [SteveViss](https://github.com/SteveViss)
 * **Timothee Poisot** - *Initial work* - [tpoisot](https://github.com/tpoisot)
-* **Gabriel Bergeron** - *Package developper* - [gabrielbouleau](https://github.com/gabrielbouleau)
+* **Gabriel Bergeron** - *Package developer* - [gabrielbouleau](https://github.com/gabrielbouleau)
 
 ## TODO
 


### PR DESCRIPTION
Hey there,

It seems that you need `httr-oauth` in the project root directory, not the R subdirectory. I also fixed a few typos.

Cheers,

Matt