### PR TITLE
:bug: a missing network is now a NA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - r: oldrel
     - os: linux
-      dist: trusty
+      dist: bionic
       r: release
       env: NOT_CRAN=true
     - os: osx
@@ -17,7 +17,7 @@ matrix:
           packages:
           - cairo
     - os: linux
-      dist: xenial
+      dist: focal
       r: devel
       env: NOT_CRAN=false
       r_github_packages:
@@ -26,9 +26,6 @@ matrix:
         - Rscript -e 'covr::codecov()'
 addons:
   apt:
-    sources:
-      - sourceline: 'ppa:opencpu/jq'
-      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
     packages:
       - libudunits2-dev
       - libproj-dev

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,9 +4,9 @@ Title: 'Mangal' Client
 Version: 2.0.1
 Authors@R: c(
     person(given = "Steve", family = "Vissault", comment = c(ORCID = "0000-0002-0866-4376"),
-      email = "steve.vissault@usherbrooke.ca", role = c("aut", "cre")),
+      email = "steve.vissault@usherbrooke.ca", role = c("aut", "ctb")),
     person(given = "Kevin", family = "Cazelles", comment = c(ORCID = "0000-0001-6619-9874"),
-        email = "kcazelle@uoguelph.ca", role = c("aut","ctb")),
+        email = "kcazelle@uoguelph.ca", role = c("aut","cre")),
     person(given = "Gabriel", family = "Bergeron",
       email = "gabriel.bergeron3@usherbrooke.ca", role = c("aut","ctb")),
     person(given = "Benjamin", family = "Mercier",
@@ -33,7 +33,7 @@ Imports:
     jsonlite (>= 1.5),
     memoise,
     purrr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Suggests:
     ggraph (>= 2.0.0),
     knitr,

--- a/R/search_datasets.R
+++ b/R/search_datasets.R
@@ -60,10 +60,13 @@ search_datasets <- function(query, verbose = TRUE, ...) {
 
   # Attached references and networks
   # No need for test because if NULL function stopped above
-  references <- networks <- NULL
+  references <- networks <- list()
   for (i in seq_len(nrow(datasets))) {
-    networks[[i]] <- get_from_fkey_net(endpoints()$network,
+    tmp <- get_from_fkey_net(endpoints()$network,
       dataset_id = datasets$id[i], verbose = verbose)
+    if (!is.null(tmp)) {
+      networks[[i]] <- tmp
+    } else networks[[i]] <- NA
     references[[i]] <- resp_to_df(get_singletons(endpoints()$reference,
       ids = datasets$ref_id[i], verbose = verbose)$body)
   }

--- a/R/search_datasets.R
+++ b/R/search_datasets.R
@@ -61,15 +61,25 @@ search_datasets <- function(query, verbose = TRUE, ...) {
   # Attached references and networks
   # No need for test because if NULL function stopped above
   references <- networks <- list()
+
   for (i in seq_len(nrow(datasets))) {
-    tmp <- get_from_fkey_net(endpoints()$network,
+
+    # Appending networks
+    tmp_networks <- get_from_fkey_net(endpoints()$network,
       dataset_id = datasets$id[i], verbose = verbose)
-    if (!is.null(tmp)) {
-      networks[[i]] <- tmp
+    if (!is.null(tmp_networks)) {
+      networks[[i]] <- tmp_networks
     } else networks[[i]] <- NA
-    references[[i]] <- resp_to_df(get_singletons(endpoints()$reference,
+
+    # Apppending references
+    tmp_references <- resp_to_df(get_singletons(endpoints()$reference,
       ids = datasets$ref_id[i], verbose = verbose)$body)
+    if (!is.null(tmp_references)) {
+      networks[[i]] <- tmp_references
+    } else networks[[i]] <- NA
+
   }
+  
   datasets$references <- references
   datasets$networks <- networks
 

--- a/R/search_datasets.R
+++ b/R/search_datasets.R
@@ -71,12 +71,12 @@ search_datasets <- function(query, verbose = TRUE, ...) {
       networks[[i]] <- tmp_networks
     } else networks[[i]] <- NA
 
-    # Apppending references
+    # Appending references
     tmp_references <- resp_to_df(get_singletons(endpoints()$reference,
       ids = datasets$ref_id[i], verbose = verbose)$body)
     if (!is.null(tmp_references)) {
-      networks[[i]] <- tmp_references
-    } else networks[[i]] <- NA
+      references[[i]] <- tmp_references
+    } else references[[i]] <- NA
 
   }
   

--- a/R/search_networks.R
+++ b/R/search_networks.R
@@ -34,9 +34,10 @@
 #' # Retrieve the search results
 #' nets_insect <- get_collection(mg_insect)
 #' # Spatial query
+#' library(sf)
 #' library(USAboundaries)
 #' area <- us_states(state="california")
-#' networks_in_area <- search_networks(area, verbose = FALSE)
+#' networks_in_area <- search_networks_sf(area, verbose = FALSE)
 #' plot(networks_in_area)
 #' }
 #' # Retrieve network ID 5013
@@ -72,7 +73,7 @@ search_networks_sf <- function(query_sf, verbose = TRUE, ...) {
   stopifnot("sf" %in% class(query_sf))
   stop_if_missing_sf()
 
-  # API doesn't allow spatial search yet, so we used sf
+  # API doesn't allow spatial search yet, so we call sf
   sp_networks_all <- resp_to_spatial(
       get_gen(endpoints()$network, verbose = verbose, ...)$body,
       as_sf = TRUE)

--- a/man/get_collection.Rd
+++ b/man/get_collection.Rd
@@ -31,13 +31,13 @@ get_collection(x, ...)
 \item{x}{\code{numeric} vector of Mangal network IDs or an object returned by
 by one of the \verb{search_*()} functions.}
 
-\item{...}{arguments to be passed on to \code{\link[rmangal:get_network_by_id]{rmangal::get_network_by_id()}}.}
+\item{...}{arguments to be passed on to \code{\link[=get_network_by_id]{get_network_by_id()}}.}
 }
 \value{
 If there is only one network to be retrieved, \code{get_collection()} returns a
 \code{mgNetwork} object, otherwise it returns a object of class
 \code{mgNetworksCollection} which is a collection (a list) of \code{mgNetwork}
-objects \code{\link[rmangal:get_network_by_id]{rmangal::get_network_by_id()}}).
+objects \code{\link[=get_network_by_id]{get_network_by_id()}}).
 }
 \description{
 Retrieve a set of networks based on the results of one of the \verb{search_*()}

--- a/man/get_from_fkey.Rd
+++ b/man/get_from_fkey.Rd
@@ -12,7 +12,7 @@ get_from_fkey(endpoint, verbose = TRUE, ...)
 \item{...}{foreign key column name with the id}
 }
 \value{
-Object returned by \code{\link[rmangal:get_gen]{rmangal::get_gen()}}
+Object returned by \code{\link[=get_gen]{get_gen()}}
 }
 \description{
 Get entries based on foreign key

--- a/man/rmangal.Rd
+++ b/man/rmangal.Rd
@@ -19,11 +19,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Steve Vissault \email{steve.vissault@usherbrooke.ca} (\href{https://orcid.org/0000-0002-0866-4376}{ORCID})
+\strong{Maintainer}: Kevin Cazelles \email{kcazelle@uoguelph.ca} (\href{https://orcid.org/0000-0001-6619-9874}{ORCID})
 
 Authors:
 \itemize{
-  \item Kevin Cazelles \email{kcazelle@uoguelph.ca} (\href{https://orcid.org/0000-0001-6619-9874}{ORCID}) [contributor]
+  \item Steve Vissault \email{steve.vissault@usherbrooke.ca} (\href{https://orcid.org/0000-0002-0866-4376}{ORCID}) [contributor]
   \item Gabriel Bergeron \email{gabriel.bergeron3@usherbrooke.ca} [contributor]
   \item Benjamin Mercier \email{Benjamin.B.Mercier@usherbrooke.ca} [contributor]
   \item Clément Violet \email{Clement.Violet@etudiant.univ-brest.fr} [contributor]

--- a/man/search_networks.Rd
+++ b/man/search_networks.Rd
@@ -52,9 +52,10 @@ mg_insect <- search_networks(query="insect\%")
 # Retrieve the search results
 nets_insect <- get_collection(mg_insect)
 # Spatial query
+library(sf)
 library(USAboundaries)
 area <- us_states(state="california")
-networks_in_area <- search_networks(area, verbose = FALSE)
+networks_in_area <- search_networks_sf(area, verbose = FALSE)
 plot(networks_in_area)
 }
 # Retrieve network ID 5013

--- a/vignettes/rmangal.Rmd
+++ b/vignettes/rmangal.Rmd
@@ -203,7 +203,7 @@ Note that if an empty character is passed, i.e. `""`, all entries are returned. 
 
 
 ```{R}
-all_datasets <- search_datasets("")
+all_datasets <- search_datasets("", verbose = FALSE)
 glimpse(all_datasets)
 ```
 


### PR DESCRIPTION
Following up on #97 and #96, this PR slightly changes the behavior of `search_datasets()` so that a missing network is now a `NA` instead of a `NULL`, otherwise we get a length issue. I think it is a better solution to prevent the package to be archived when there is something wrong with the data. That said, it would be good to have an automated procedure to monitor data quality. 
Something as simple as checking whether there are `NA`s returned. 


```R
checking examples with --run-donttest ...
```

There was another error caused by the following example in `search_networks()` 
(it was an donttest one, so no biggie):

```R
library(USAboundaries)
area <- us_states(state="california")
networks_in_area <- search_networks_sf(area, verbose = FALSE)
plot(networks_in_area)
```

This was solved (in this PR) by loading {sf} (it caused the same issue as the one described in https://github.com/r-spatial/sf/issues/1185). No errors and no warnings locally.