### PR TITLE
Remove purrr from Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,10 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Imports:
     httr (>= 1.3.1),
-    igraph,
+    igraph (>= 1.2.1),
     jsonlite (>= 1.5),
     memoise,
-    methods,
-    purrr
+    methods
 RoxygenNote: 7.1.2
 Suggests:
     ggraph (>= 2.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Add lintr workflow to automatically.
 * Summary method for `mgNetwork` objects now reports nodes and properly (see nodes #108).
+* `purrr` is no longer listed as an imported package.
 
 # rmangal 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # rmangal (devel)
 
+* `inherits()` is now used to test classes.
+* `purrr` is no longer listed as an imported package.
 * Add lintr workflow to automatically.
 * Summary method for `mgNetwork` objects now reports nodes and properly (see nodes #108).
-* `purrr` is no longer listed as an imported package.
 
 # rmangal 2.1.0
 

--- a/R/combine_mgNetworks.R
+++ b/R/combine_mgNetworks.R
@@ -13,13 +13,13 @@
 #'  mg_random_1071 <- get_collection(c(1071))
 #'  mg_random_1074 <- get_collection(c(1074))
 #'  combine_mgNetworks(mg_random_1071, mg_random_1074)
-#' } 
+#' }
 #'
 #' @export
 combine_mgNetworks <- function(...) {
   lsmg <- list(...)
   if (length(lsmg) == 1) {
-    if (class(lsmg[[1L]]) == "mgNetwork") {
+    if (inherits(lsmg[[1L]], "mgNetwork")) {
       return(structure(list(lsmg), class = "mgNetworksCollection"))
     } else lsmg <- unlist(lsmg, recursive = FALSE)
   }
@@ -28,10 +28,10 @@ combine_mgNetworks <- function(...) {
 }
 
 unlist_mgNetworks <- function(x) {
-    if (class(x) == "mgNetworksCollection") {
+    if (inherits(x, "mgNetworksCollection")) {
       unclass(x)
     } else {
-      if (class(x) == "mgNetwork") {
+      if (inherits(x, "mgNetwork")) {
         list(x)
       } else stop("Only 'mgNetwork' and `mgNetworksCollection` objects are
         supported")

--- a/R/get_citations.R
+++ b/R/get_citations.R
@@ -14,7 +14,7 @@
 #'  mg_18 <- get_network_by_id(18)
 #'  get_citation(mg_18)
 #' }
-#' 
+#'
 #' @export
 get_citation <- function(x) {
   UseMethod("get_citation", x)
@@ -27,5 +27,5 @@ get_citation.mgNetwork <- function(x) x$reference$bibtex
 #' @describeIn get_citation Get BibTeX entries for the publication associated to the networks.
 #' @export
 get_citation.mgNetworksCollection <- function(x) {
-    unique(unlist(purrr::map(x, get_citation)))
+    unique(unlist(lapply(x, function(y) get_citation(y))))
 }

--- a/R/get_collection.R
+++ b/R/get_collection.R
@@ -8,7 +8,7 @@
 #' @param ... arguments to be passed on to [rmangal::get_network_by_id()].
 #'
 #' @return
-#'  Returns a object of class `mgNetworksCollection` which is a collection 
+#'  Returns a object of class `mgNetworksCollection` which is a collection
 #' (actually, a list) of `mgNetwork` objects [rmangal::get_network_by_id()]).
 #'
 #' @seealso
@@ -36,7 +36,7 @@ get_collection.default <- function(x, ...) {
 #' @export
 get_collection.mgSearchDatasets <- function(x, ...) {
   # Get networks ids
-  net_ids <- unique(unlist(purrr::map(x$networks, "id")))
+  net_ids <- unique(unlist(lapply(x$networks, function(x) x$id)))
   get_collection.default(net_ids, ...)
 }
 
@@ -52,7 +52,7 @@ get_collection.mgSearchNetworks <- function(x, ...) {
 #' @export
 get_collection.mgSearchReferences <- function(x, ...) {
   # Get networks ids
-  net_ids <- unique(unlist(purrr::map(x$networks, "id")))
+  net_ids <- unique(unlist(lapply(x$networks, function(x) x$id)))
   get_collection.default(net_ids, ...)
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -212,14 +212,14 @@ get_gen <- function(endpoint, query = NULL, limit = 100, verbose = TRUE, ...) {
   resp <- mem_get(url,
       config = httr::add_headers(`Content-type` = "application/json"), ua,
       query = query, ...)
-      
+
   # Stop if server status is problematic
   httr::stop_for_status(resp)
 
   # Prep output object
   responses <- list()
   errors <- NULL
-  
+
 
   # Get # pages
   tmp <- unlist(strsplit(httr::headers(resp)$"content-range", split = "\\D"))
@@ -252,8 +252,8 @@ get_gen <- function(endpoint, query = NULL, limit = 100, verbose = TRUE, ...) {
 
   # check error here if desired;
   out <- list(
-    body = unlist(purrr::map(responses, "body"), recursive = FALSE),
-    response = purrr::map(responses, "response")
+    body = unlist(lapply(responses, function(x) x$body), recursive = FALSE),
+    response = lapply(responses, function(x) x$response)
   )
   class(out) <- "mgGetResponses"
   out
@@ -325,7 +325,7 @@ msg_request_fail <- function(resp) {
 
 
 handle_query <- function(query, names_available) {
-  if (is.character(query)) 
+  if (is.character(query))
     return(list(q = query))
   if (!is.list(query))
     stop("`query` should either be a list or a character string.",
@@ -367,4 +367,3 @@ print_net_info <- function(net_id, dat_id, descr, n_edg, n_nod) {
     "* Includes ", n_edg, " edges and ", n_nod, " nodes \n"
   )
 }
-

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,26 +1,26 @@
 {
-  "@context": [
-    "https://doi.org/10.5063/schema/codemeta-2.0",
-    "http://schema.org"
-  ],
+  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "rmangal",
   "description": "An interface to the 'Mangal' database - a collection of ecological networks. This package includes functions to work with the 'Mangal RESTful API' methods (<https://mangal-interactions.github.io/mangal-api/>).",
   "name": "rmangal: 'Mangal' Client",
+  "relatedLink": ["https://docs.ropensci.org/rmangal/", "https://mangal.io", "https://CRAN.R-project.org/package=rmangal"],
   "codeRepository": "https://github.com/ropensci/rmangal",
-  "relatedLink": [
-    "https://docs.ropensci.org/rmangal/",
-    "https://mangal.io"
-  ],
   "issueTracker": "https://github.com/ropensci/rmangal/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "2.1.0",
+  "version": "2.1.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.1.2 (2021-11-01)",
+  "runtimePlatform": "R version 4.2.0 (2022-04-22)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Comprehensive R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
   "author": [
     {
       "@type": "Person",
@@ -94,8 +94,6 @@
       "email": "Clement.Violet@etudiant.univ-brest.fr"
     }
   ],
-  "copyrightHolder": {},
-  "funder": {},
   "maintainer": [
     {
       "@type": "Person",
@@ -264,8 +262,8 @@
       "sameAs": "https://CRAN.R-project.org/package=vcr"
     }
   ],
-  "softwareRequirements": [
-    {
+  "softwareRequirements": {
+    "1": {
       "@type": "SoftwareApplication",
       "identifier": "httr",
       "name": "httr",
@@ -278,10 +276,11 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=httr"
     },
-    {
+    "2": {
       "@type": "SoftwareApplication",
       "identifier": "igraph",
       "name": "igraph",
+      "version": ">= 1.2.1",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
@@ -290,7 +289,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=igraph"
     },
-    {
+    "3": {
       "@type": "SoftwareApplication",
       "identifier": "jsonlite",
       "name": "jsonlite",
@@ -303,7 +302,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=jsonlite"
     },
-    {
+    "4": {
       "@type": "SoftwareApplication",
       "identifier": "memoise",
       "name": "memoise",
@@ -315,37 +314,17 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=memoise"
     },
-    {
+    "5": {
       "@type": "SoftwareApplication",
       "identifier": "methods",
       "name": "methods"
     },
-    {
-      "@type": "SoftwareApplication",
-      "identifier": "purrr",
-      "name": "purrr",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=purrr"
-    }
-  ],
+    "SystemRequirements": null
+  },
   "applicationCategory": "ecologicalNetworks",
   "isPartOf": "https://ropensci.org",
   "keywords": ["ecology", "networks", "foodwebs", "interactions", "datapublications", "openaccess"],
-  "releaseNotes": "https://github.com/ropensci/rmangal/blob/master/NEWS.md",
-  "readme": "https://github.com/ropensci/rmangal/blob/main/README.md",
-  "fileSize": "3680.388KB",
-  "contIntegration": ["https://github.com/ropensci/rmangal/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/ropensci/ropensci/rmangal"],
-  "developmentStatus": "https://www.repostatus.org/#active",
-  "review": {
-    "@type": "Review",
-    "url": "https://github.com/ropensci/software-review/issues/332",
-    "provider": "https://ropensci.org"
-  },
+  "fileSize": "3445.83KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",
@@ -388,7 +367,17 @@
         }
       ],
       "name": "rmangal: An R package to interact with Mangal database",
-      "url": "https://docs.ropensci.org/rmangal/"
+      "url": "https://docs.ropensci.org/rmangal/",
+      "description": "R package version 2.1.0.9000"
     }
-  ]
+  ],
+  "releaseNotes": "https://github.com/ropensci/rmangal/blob/master/NEWS.md",
+  "readme": "https://github.com/ropensci/rmangal/blob/main/README.md",
+  "contIntegration": ["https://github.com/ropensci/rmangal/actions/workflows/R-CMD-check.yaml", "https://app.codecov.io/gh/ropensci/ropensci/rmangal"],
+  "developmentStatus": "https://www.repostatus.org/#active",
+  "review": {
+    "@type": "Review",
+    "url": "https://github.com/ropensci/software-review/issues/332",
+    "provider": "https://ropensci.org"
+  }
 }

--- a/man/combine_mgNetworks.Rd
+++ b/man/combine_mgNetworks.Rd
@@ -21,6 +21,6 @@ Combine \code{mgNetworksCollection} and \code{mgNetwork} objects into a
  mg_random_1071 <- get_collection(c(1071))
  mg_random_1074 <- get_collection(c(1074))
  combine_mgNetworks(mg_random_1071, mg_random_1074)
-} 
+}
 
 }


### PR DESCRIPTION
* `inherits()` is now used to test classes.
* `purrr` is no longer listed as an imported package.