### PR TITLE
Minor tweaks to failGracefully PR

### DIFF
--- a/R/client_core.R
+++ b/R/client_core.R
@@ -56,7 +56,7 @@ rmangal_request <- function(endpoint, query = NULL, limit = 100, cache = FALSE, 
 }
 
 
-rmangal_request_singleton <- function(endpoint = "", id, cache = FALSE, ...) {
+rmangal_request_singleton <- function(endpoint, id, cache = FALSE, ...) {
   stopifnot(length(id) == 1)
   req <- rmangal_api_url() |>
     httr2::req_url_path_append(rmangal_endpoint_path(endpoint)) |>

--- a/vignettes/rmangal.Rmd
+++ b/vignettes/rmangal.Rmd
@@ -121,6 +121,20 @@ returns a `mgNetwork` object, otherwise it returns an object of class
 Below, we exemplify how to use the search functions, how to get a collection of
 networks and how to use other packages to carry out specific analyses.
 
+### Verbosity
+Verbosity is defined at the package level in `rmangal`, controlled by the option `rmangal.verbose`.
+
+To quiet all rmangal function, use: 
+
+```R
+options(rmangal.verbose = "quiet")
+```
+
+and to switch on the verbosity do:
+
+```R
+options(rmangal.verbose = "verbose")
+```
 
 ## Search functions
 


### PR DESCRIPTION
## Description

1. Removed the default empty string on `endpoint` parameter  of `rmangal_request_singleton`
2. Added the same information on package verbosity found in the README to the vignette.

* To be merged in the PR #117 *